### PR TITLE
Make sure assetslib does not see no needed files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Exclude all top-level files and directories
+# (except addons) from zip downloads.
+/.gitattributes   export-ignore
+/.gitignore       export-ignore
+/CHANGELOG.md     export-ignore
+/default_env.tres export-ignore
+/icon.png         export-ignore
+/icon.png.import  export-ignore
+/project.godot    export-ignore
+/media            export-ignore
+/LICENSE          export-ignore
+/README.md        export-ignore
+/screenshots      export-ignore


### PR DESCRIPTION
When installing through AssetsLib

![Screenshot 2020-11-26 at 16 54 33](https://user-images.githubusercontent.com/371014/100372136-1a5be100-3009-11eb-8862-afecfb5676e7.png)

on has to unselect some files and others are unnessary to see.

![Screenshot 2020-11-26 at 16 55 08](https://user-images.githubusercontent.com/371014/100372212-365f8280-3009-11eb-84e9-ce7771b73806.png)

By adding `.gitattributes` your ZIP download gets way smaller.

See also https://github.com/bitwes/Gut/blob/master/.gitattributes and https://github.com/clemens-tolboom/godot_3_spawn_points/blob/develop/.gitattributes and their ZIP downloads at both GitHub and AssetsLib